### PR TITLE
deps: stay on typescript 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
 
+      # eslint 8 doesn't support typescript 6 or higher
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Eslint 8 doesn't seem to support typescript 6 so we should stay on 5

If this looks okay, I'll update this to our other repos too