### PR TITLE
Add option to accept or discard external modifications

### DIFF
--- a/po/bootloader.pot
+++ b/po/bootloader.pot
@@ -22,7 +22,7 @@ msgstr ""
 "#-#-#-#-#  bootloader.js.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-14 10:24+0200\n"
+"POT-Creation-Date: 2026-04-08 11:39+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgstr ""
 "#-#-#-#-#  bootloader.metainfo.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-28 12:08+0200\n"
+"POT-Creation-Date: 2025-11-24 10:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,11 +48,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: src/app.tsx:152
+msgid "Accept"
+msgstr ""
+
 #: src/app.tsx:103
 msgid "Administrative access is required."
 msgstr ""
 
-#: src/app.tsx:222
+#: src/app.tsx:233
 msgid "Advanced"
 msgstr ""
 
@@ -64,11 +68,11 @@ msgstr ""
 msgid "Autodetect by grub2"
 msgstr ""
 
-#: src/app.tsx:178
+#: src/app.tsx:189
 msgid "Booloader service (bootkit) is not active"
 msgstr ""
 
-#: src/app.tsx:216
+#: src/app.tsx:227
 msgid "Boot Options"
 msgstr ""
 
@@ -84,7 +88,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/app.tsx:145
+#: src/app.tsx:148
 msgid "Changes made to grub config"
 msgstr ""
 
@@ -141,6 +145,10 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
+#: src/app.tsx:155
+msgid "Discard"
+msgstr ""
+
 #: src/pages/advanced.tsx:73
 msgid "Edit"
 msgstr ""
@@ -189,7 +197,7 @@ msgstr ""
 msgid "Is selected"
 msgstr ""
 
-#: src/app.tsx:210
+#: src/app.tsx:221
 msgid "Kernel Parameters"
 msgstr ""
 
@@ -217,11 +225,16 @@ msgstr ""
 msgid "No grub bootloader found"
 msgstr ""
 
-#: src/app.tsx:238
+#: src/app.tsx:146
+msgid ""
+"Or you can discard these changes to revert to currently selected snapshot."
+msgstr ""
+
+#: src/app.tsx:249
 msgid "Reset"
 msgstr ""
 
-#: src/app.tsx:235 src/pages/advanced.tsx:44
+#: src/app.tsx:246 src/pages/advanced.tsx:44
 msgid "Save"
 msgstr ""
 
@@ -233,7 +246,7 @@ msgstr ""
 msgid "Selected kernel"
 msgstr ""
 
-#: src/app.tsx:228
+#: src/app.tsx:239
 msgid "Snapshots"
 msgstr ""
 
@@ -245,7 +258,7 @@ msgstr ""
 msgid "This is caused by manual configuration changes."
 msgstr ""
 
-#: src/app.tsx:179
+#: src/app.tsx:190
 msgid "Troubleshoot"
 msgstr ""
 
@@ -263,4 +276,8 @@ msgstr ""
 
 #: src/pages/snapshots.tsx:181
 msgid "Yes"
+msgstr ""
+
+#: src/app.tsx:145
+msgid "You can accept these changes to create a new snapshot."
 msgstr ""

--- a/src/app.scss
+++ b/src/app.scss
@@ -9,3 +9,9 @@ p {
     border-radius: 2px;
     border-color: var(--pf-t--global--color--status--danger--default);
 }
+
+.grub-error-area-buttons {
+    margin-top: 24px;
+    border-top: 1px solid;
+    padding-top: 8px;
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -129,7 +129,7 @@ const GrubErrorArea = () => {
 };
 
 const GrubConfigMismatch = () => {
-    const { config } = useBootKitContext();
+    const { config, saveConfig, selectCurrentSnapshot } = useBootKitContext();
 
     if (!config.config_diff) {
         return null;
@@ -142,8 +142,19 @@ const GrubConfigMismatch = () => {
                     <h1>{_("Grub2 config doesn't match the selected snapshot.")}</h1>
                     <p>{_("This is caused by manual configuration changes.")}</p>
                     <br />
+                    <p>{_("You can accept these changes to create a new snapshot.")}</p>
+                    <p>{_("Or you can discard these changes to revert to currently selected snapshot.")}</p>
+                    <br />
                     <h3>{_("Changes made to grub config")}</h3>
                     <pre>{config.config_diff}</pre>
+                    <div className='grub-error-area-buttons'>
+                        <Button variant="primary" onClick={() => saveConfig()}>
+                            {_("Accept")}
+                        </Button>
+                        <Button variant="danger" onClick={() => selectCurrentSnapshot()}>
+                            {_("Discard")}
+                        </Button>
+                    </div>
                 </div>
             </Flex>
         </PageSection>

--- a/src/state/bootkit_provider.tsx
+++ b/src/state/bootkit_provider.tsx
@@ -80,6 +80,7 @@ export interface BootKitContextType {
     resetConfig: () => void,
     removeSnapshot: (id: number) => void,
     selectSnapshot: (id: number) => void,
+    selectCurrentSnapshot: () => void,
     updateConfig: (key: KeyValue | string, value: string) => void,
     setBootEntry: (entry: string) => void,
 }
@@ -94,6 +95,7 @@ const BootKitContext = createContext<BootKitContextType>({
     resetConfig: () => { },
     removeSnapshot: () => { },
     selectSnapshot: () => { },
+    selectCurrentSnapshot: () => { },
     updateConfig: () => { },
     setBootEntry: () => { },
 });
@@ -144,6 +146,11 @@ const bootKitSelectSnapshot = (id: number) => {
     const arg = { snapshot_id: id };
     return cockpit.dbus(DBUS_NAME, { superuser: "require" })
                     .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "SelectSnapshot", [JSON.stringify(arg)]) as Promise<JsonPromise<string>>;
+};
+
+const bootKitUseCurrentSnapshot = () => {
+    return cockpit.dbus(DBUS_NAME, { superuser: "require" })
+                    .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "UseCurrentSnapshot", []) as Promise<JsonPromise<string>>;
 };
 
 const bootKitLoadSnapshots = (): Promise<JsonPromise<BootkitSnapshots>> => {
@@ -260,6 +267,11 @@ export function BootKitProvider({ children }: { children: React.ReactNode }) {
         await loadAll();
     };
 
+    const useAndLoadCurrentSnapshot = async () => {
+        await useCurrentSnapshot();
+        await loadAll();
+    };
+
     const loadAll = async () => {
         updateState({ loading: true });
         await loadConfig();
@@ -308,6 +320,7 @@ export function BootKitProvider({ children }: { children: React.ReactNode }) {
     const loadBootEntries = bootKitCall(bootKitLoadBootEntries, setStateError, (entries) => setBootEntries(entries.entries));
     const removeSnapshot = bootKitCall(bootKitRemoveSnapshot, setStateError);
     const selectSnapshot = bootKitCall(bootKitSelectSnapshot, setStateError);
+    const useCurrentSnapshot = bootKitCall(bootKitUseCurrentSnapshot, setStateError);
 
     return (
         <BootKitContext.Provider
@@ -323,6 +336,7 @@ export function BootKitProvider({ children }: { children: React.ReactNode }) {
                 snapshots,
                 removeSnapshot: removeAndLoadSnapshot,
                 selectSnapshot: selectAndLoadSnapshot,
+                selectCurrentSnapshot: useAndLoadCurrentSnapshot,
             }}
         >
             {children}


### PR DESCRIPTION
This depends on org.opensuse.bootkit.Snapshot UseCurrentSnapshot to be implemented in bootkitd.

This should fix the issue in https://github.com/openSUSE/cockpit-bootloader/issues/22

The new error UI:
<img width="1134" height="512" alt="image" src="https://github.com/user-attachments/assets/614814d6-d2ce-408d-8ba1-c33ce01711c5" />
