### PR TITLE
Support new bootloader agnostic bootkitd API

### DIFF
--- a/po/bootloader.pot
+++ b/po/bootloader.pot
@@ -22,7 +22,7 @@ msgstr ""
 "#-#-#-#-#  bootloader.js.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-15 13:36+0300\n"
+"POT-Creation-Date: 2026-06-15 10:48+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgstr ""
 "#-#-#-#-#  bootloader.metainfo.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-24 10:14+0200\n"
+"POT-Creation-Date: 2026-06-11 13:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,39 +48,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/app.tsx:192
+#: src/app.tsx:184
 msgid "Accept"
 msgstr ""
 
-#: src/app.tsx:120
+#: src/app.tsx:103
 msgid "Administrative access is required."
 msgstr ""
 
-#: src/app.tsx:274
+#: src/app.tsx:257
 msgid "Advanced"
 msgstr ""
 
-#: src/app.tsx:116
+#: src/app.tsx:99
 msgid "Authentication error"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:15 src/pages/kernel_params.tsx:46
+#: src/pages/kernel_params.tsx:35
 msgid "Autodetect by grub2"
 msgstr ""
 
-#: src/app.tsx:229
+#: src/app.tsx:216
 msgid "Booloader service (bootkit) is not active"
 msgstr ""
 
-#: src/app.tsx:268
+#: src/app.tsx:251
 msgid "Boot Options"
 msgstr ""
 
-#: src/pages/boot_options.tsx:19
+#: src/pages/boot_options.tsx:45
 msgid "Boot entry"
 msgstr ""
 
-#: src/app.tsx:139
+#: src/app.tsx:122
 msgid "Bootkitd service is outdated. Please update it."
 msgstr ""
 
@@ -88,11 +88,15 @@ msgstr ""
 msgid "Bootloader"
 msgstr ""
 
-#: src/pages/advanced.tsx:48 src/pages/snapshots.tsx:89
+#: src/app.tsx:174
+msgid "Bootloader config doesn't match the selected snapshot."
+msgstr ""
+
+#: src/pages/snapshots.tsx:97
 msgid "Cancel"
 msgstr ""
 
-#: src/app.tsx:188
+#: src/app.tsx:180
 msgid "Changes made to grub config"
 msgstr ""
 
@@ -105,79 +109,67 @@ msgstr ""
 msgid "Cockpit module for editing bootloader settings"
 msgstr ""
 
-#: src/pages/snapshots.tsx:166
+#: src/pages/snapshots.tsx:174
 msgid "Config"
 msgstr ""
 
-#: src/pages/snapshots.tsx:87
+#: src/pages/snapshots.tsx:95
 msgid "Confirm"
 msgstr ""
 
-#: src/pages/snapshots.tsx:131
+#: src/pages/snapshots.tsx:139
 msgid "Confirm deleting snapshot"
 msgstr ""
 
-#: src/pages/snapshots.tsx:119
+#: src/pages/snapshots.tsx:127
 msgid "Confirm selecting snapshot"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:44
+#: src/pages/kernel_params.tsx:33
 msgid "Console resolution"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:53
+#: src/pages/kernel_params.tsx:42
 msgid "Console theme"
 msgstr ""
 
-#: src/pages/snapshots.tsx:168
+#: src/pages/snapshots.tsx:176
 msgid "Created"
 msgstr ""
 
-#: src/pages/snapshots.tsx:182
+#: src/pages/snapshots.tsx:180
 msgid "Default"
 msgstr ""
 
-#: src/pages/snapshots.tsx:136
+#: src/pages/snapshots.tsx:144
 msgid "Delete"
 msgstr ""
 
-#: src/pages/snapshots.tsx:36
-msgid "Difference between current grub config"
+#: src/pages/snapshots.tsx:47
+msgid "Difference between current config"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:39
+#: src/pages/kernel_params.tsx:28
 msgid "Disable"
 msgstr ""
 
-#: src/app.tsx:195
+#: src/app.tsx:187
 msgid "Discard"
 msgstr ""
 
-#: src/pages/advanced.tsx:74
-msgid "Edit"
-msgstr ""
-
-#: src/pages/advanced.tsx:20
-msgid "Edit GRUB value"
-msgstr ""
-
-#: src/pages/kernel_params.tsx:27
+#: src/pages/kernel_params.tsx:16
 msgid "Enable"
 msgstr ""
 
-#: src/pages/snapshots.tsx:49
-msgid "Full GRUB config file"
-msgstr ""
-
-#: src/pages/snapshots.tsx:161
+#: src/pages/snapshots.tsx:169
 msgid "GRUB snapshots"
 msgstr ""
 
-#: src/pages/advanced.tsx:63
+#: src/pages/advanced.tsx:16
 msgid "GRUB values"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:26 src/pages/kernel_params.tsx:37
+#: src/pages/kernel_params.tsx:15 src/pages/kernel_params.tsx:26
 msgid "Graphical console"
 msgstr ""
 
@@ -185,111 +177,103 @@ msgstr ""
 msgid "Grub"
 msgstr ""
 
-#: src/app.tsx:182
-msgid "Grub2 config doesn't match the selected snapshot."
-msgstr ""
-
-#: src/pages/snapshots.tsx:164
+#: src/pages/snapshots.tsx:172
 msgid "Id"
 msgstr ""
 
-#: src/pages/snapshots.tsx:40
+#: src/pages/snapshots.tsx:51
 msgid "Identical to the current config"
 msgstr ""
 
-#: src/pages/snapshots.tsx:165
+#: src/pages/snapshots.tsx:173
 msgid "Is selected"
 msgstr ""
 
-#: src/app.tsx:262
+#: src/app.tsx:245
 msgid "Kernel Parameters"
 msgstr ""
 
-#: src/pages/kernel_params.tsx:74
+#: src/pages/kernel_params.tsx:69
 msgid "Kernel parameters"
 msgstr ""
 
-#: src/pages/advanced.tsx:27 src/pages/advanced.tsx:66
+#: src/pages/advanced.tsx:19
 msgid "Key"
 msgstr ""
 
-#: src/app.tsx:76
+#: src/app.tsx:75
 msgid "Loading Grub information"
 msgstr ""
 
-#: src/app.tsx:92
-msgid "Make sure you have grub installed and that /etc/default/grub exists"
-msgstr ""
-
-#: src/pages/snapshots.tsx:179
+#: src/pages/snapshots.tsx:187
 msgid "No"
 msgstr ""
 
-#: src/app.tsx:88
-msgid "No grub bootloader found"
-msgstr ""
-
-#: src/app.tsx:186
+#: src/app.tsx:178
 msgid ""
 "Or you can discard these changes to revert to currently selected snapshot."
 msgstr ""
 
-#: src/app.tsx:141
+#: src/app.tsx:124
 msgid "Required version"
 msgstr ""
 
-#: src/app.tsx:290
+#: src/app.tsx:273
 msgid "Reset"
 msgstr ""
 
-#: src/app.tsx:287 src/pages/advanced.tsx:45
+#: src/app.tsx:270
 msgid "Save"
 msgstr ""
 
-#: src/pages/snapshots.tsx:124
+#: src/pages/snapshots.tsx:132
 msgid "Select"
 msgstr ""
 
-#: src/pages/snapshots.tsx:167
+#: src/pages/snapshots.tsx:175
 msgid "Selected kernel"
 msgstr ""
 
-#: src/app.tsx:143
+#: src/app.tsx:126
 msgid "Service version"
 msgstr ""
 
-#: src/app.tsx:280
+#: src/app.tsx:263
 msgid "Snapshots"
 msgstr ""
 
-#: src/pages/snapshots.tsx:77
+#: src/pages/snapshots.tsx:85
 msgid "This action cannot be reversed"
 msgstr ""
 
-#: src/app.tsx:183
+#: src/app.tsx:175
 msgid "This is caused by manual configuration changes."
 msgstr ""
 
-#: src/app.tsx:230
+#: src/pages/boot_options.tsx:33
+msgid "Timeout"
+msgstr ""
+
+#: src/app.tsx:217
 msgid "Troubleshoot"
 msgstr ""
 
-#: src/app.tsx:162
+#: src/app.tsx:145
 msgid "Unexpected error from the bootkit service!"
 msgstr ""
 
-#: src/app.tsx:104
-msgid "Updating grub configuration"
+#: src/app.tsx:87
+msgid "Updating bootloader configuration"
 msgstr ""
 
-#: src/pages/advanced.tsx:35 src/pages/advanced.tsx:67
+#: src/pages/advanced.tsx:20
 msgid "Value"
 msgstr ""
 
-#: src/pages/snapshots.tsx:178
+#: src/pages/snapshots.tsx:186
 msgid "Yes"
 msgstr ""
 
-#: src/app.tsx:185
+#: src/app.tsx:177
 msgid "You can accept these changes to create a new snapshot."
 msgstr ""

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,13 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Button, Content, ContentVariants, Flex, FlexItem, Page, PageSection, PageSectionVariants, PageSidebar, Stack, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import { WithDialogs } from 'dialogs';
 import cockpit from 'cockpit';
 import { superuser } from 'superuser';
-import { fsinfo } from 'cockpit/fsinfo';
 import { EmptyStatePanel } from 'cockpit-components-empty-state';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -37,7 +36,7 @@ const _ = cockpit.gettext;
 
 type Pages = "advanced" | "boot-options" | "kernel-params" | "snapshots" ;
 
-const REQUIRED_BOOTKITD_VER = "0.4.0";
+const REQUIRED_BOOTKITD_VER = "0.5.0";
 
 const isValidSemVer = (version: string): boolean => {
     const bootkitVersion = version.split(".").map(Number);
@@ -81,27 +80,11 @@ const LoadingGrub = () => {
     );
 };
 
-const GrubNotFound = () => {
+const UpdatingBootloader = () => {
     return (
         <Stack>
             <EmptyStatePanel
-                title={ _("No grub bootloader found") }
-                icon={ ExclamationCircleIcon }
-                paragraph={
-                    <Content component={ContentVariants.p}>
-                        {_("Make sure you have grub installed and that /etc/default/grub exists")}
-                    </Content>
-                }
-            />
-        </Stack>
-    );
-};
-
-const UpdatingGrub = () => {
-    return (
-        <Stack>
-            <EmptyStatePanel
-                title={_("Updating grub configuration")}
+                title={_("Updating bootloader configuration")}
                 icon={ExclamationCircleIcon}
                 loading
             />
@@ -148,7 +131,7 @@ const OldBootkitdVersionError = () => {
     );
 };
 
-const GrubErrorArea = () => {
+const BootkitErrorArea = () => {
     const { state } = useBootKitContext();
 
     if (!state.error) {
@@ -168,10 +151,19 @@ const GrubErrorArea = () => {
     );
 };
 
-const GrubConfigMismatch = () => {
+const ConfigMismatch = ({ name, diff }: { name: string, diff: string }) => {
+    return (
+        <>
+            <h2>{name}</h2>
+            <pre>{diff}</pre>
+        </>
+    );
+};
+
+const BootkitConfigMismatch = () => {
     const { config, saveConfig, selectCurrentSnapshot } = useBootKitContext();
 
-    if (!config.config_diff) {
+    if (!config.config_diffs) {
         return null;
     }
 
@@ -179,14 +171,14 @@ const GrubConfigMismatch = () => {
         <PageSection variant={PageSectionVariants.default} className='grub-error-area'>
             <Flex align={ { default: 'alignLeft' } }>
                 <div>
-                    <h1>{_("Grub2 config doesn't match the selected snapshot.")}</h1>
+                    <h1>{_("Bootloader config doesn't match the selected snapshot.")}</h1>
                     <p>{_("This is caused by manual configuration changes.")}</p>
                     <br />
                     <p>{_("You can accept these changes to create a new snapshot.")}</p>
                     <p>{_("Or you can discard these changes to revert to currently selected snapshot.")}</p>
                     <br />
                     <h3>{_("Changes made to grub config")}</h3>
-                    <pre>{config.config_diff}</pre>
+                    {Object.entries(config.config_diffs).map(([name, diff]) => <ConfigMismatch key={name} name={name} diff={diff} />)}
                     <div className='grub-error-area-buttons'>
                         <Button variant="primary" onClick={() => saveConfig()}>
                             {_("Accept")}
@@ -206,15 +198,10 @@ const emptySidebar = <PageSidebar isSidebarOpen={false} />;
 
 const ApplicationInner = () => {
     const [page, setPage] = React.useState<Pages>("kernel-params");
-    const [hasGrub, setHasGrub] = useState<boolean | undefined>(undefined);
     const [authenticated, setAuthenticated] = React.useState(superuser.allowed);
     const context = useBootKitContext();
 
     useEffect(() => {
-        fsinfo('/etc/default/grub', [])
-                        .then(() => setHasGrub(true))
-                        .catch(() => setHasGrub(false));
-
         superuser.addEventListener("changed", () => { setAuthenticated(superuser.allowed) });
     }, []);
 
@@ -238,20 +225,16 @@ const ApplicationInner = () => {
         return <LoadingGrub />;
     }
 
-    if (hasGrub === false) {
-        return <GrubNotFound />;
-    }
-
     if (context.state.saving) {
-        return <UpdatingGrub />;
+        return <UpdatingBootloader />;
     }
 
     return (
         <WithDialogs>
             <Page sidebar={emptySidebar} className='no-masthead-sidebar'>
                 <OldBootkitdVersionError />
-                <GrubErrorArea />
-                <GrubConfigMismatch />
+                <BootkitErrorArea />
+                <BootkitConfigMismatch />
                 <PageSection variant={PageSectionVariants.default}>
                     <Flex>
                         <FlexItem align={{ default: 'alignLeft' }}>

--- a/src/pages/advanced.tsx
+++ b/src/pages/advanced.tsx
@@ -1,63 +1,16 @@
 import React from 'react';
-import { Form, TextInput, FormGroup, ActionGroup, Button, Modal, ModalHeader } from '@patternfly/react-core';
 
-import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 
 import { ListingTable } from 'cockpit-components-table.jsx';
 import { useBootKitContext } from '../state/bootkit_provider';
-import { KeyValue } from '../state/bootkitd';
 
 const _ = cockpit.gettext;
 
-export const KeyValDialog = ({ keyval }: { keyval: KeyValue }) => {
-    const Dialogs = useDialogs();
-    const context = useBootKitContext();
-    const [newValue, setNewValue] = React.useState(keyval.value);
-
-    return (
-        <Modal
-            title={_("Edit GRUB value")}
-            variant="small"
-            onClose={() => Dialogs.close()}
-            isOpen
-        >
-            <ModalHeader>
-                <Form>
-                    <FormGroup label={_("Key")} fieldId="key">
-                        <TextInput
-                            aria-label="Key"
-                            value={keyval.key}
-                            placeholder=""
-                            isDisabled
-                        />
-                    </FormGroup>
-                    <FormGroup label={_("Value")} fieldId="value">
-                        <TextInput
-                            aria-label="Value"
-                            value={newValue}
-                            placeholder=""
-                            onChange={(_event, value) => setNewValue(value)}
-                        />
-                    </FormGroup>
-                    <ActionGroup>
-                        <Button variant="primary" onClick={() => { context.updateConfig(keyval, newValue); Dialogs.close() }}>
-                            {_("Save")}
-                        </Button>
-                        <Button variant="secondary" onClick={() => Dialogs.close()}>
-                            {_("Cancel")}
-                        </Button>
-                    </ActionGroup>
-                </Form>
-            </ModalHeader>
-        </Modal>
-    );
-};
-
 export const AdvancedValues = () => {
-    const Dialogs = useDialogs();
     const context = useBootKitContext();
-
+    // TODO: separate view for advanced values for each config
+    // TODO: advanced values editina and saving
     return (
         <ListingTable
             aria-label={_("GRUB values")}
@@ -66,12 +19,11 @@ export const AdvancedValues = () => {
                 { title: _("Key") },
                 { title: _("Value") },
             ]}
-            rows={context.config.value_list.map((pkg) => {
+            rows={(context.configsRaw.configs[0]?.file.values || []).map((kv) => {
                 return {
                     columns: [
-                        { title: pkg.key },
-                        { title: pkg.value },
-                        { title: <Button onClick={() => Dialogs.show(<KeyValDialog keyval={pkg} />)}>{_("Edit")}</Button> },
+                        { title: kv[0] },
+                        { title: kv[1] },
                     ]
                 };
             })}

--- a/src/pages/boot_options.tsx
+++ b/src/pages/boot_options.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Form, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Form, FormGroup, FormSelect, FormSelectOption, NumberInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 import { useBootKitContext } from '../state/bootkit_provider';
 
@@ -13,8 +13,35 @@ export const BootOptions = () => {
         updateConfig("boot_entries.selected", entry);
     };
 
+    const onTimeoutChange = (event: React.FormEvent<HTMLInputElement>) => {
+        const value = (event.target as HTMLInputElement).value;
+        updateConfig("timeout", value);
+    };
+
+    const calcTimeout = (value: number) => {
+        let timeout = Number(config.timeout) || 0;
+        timeout += value;
+        if (timeout < 0) {
+            timeout = 0;
+        }
+
+        updateConfig("timeout", timeout.toString());
+    };
+
     return (
         <Form>
+            <FormGroup label={_("Timeout")} type="number" fieldId="bootloader-timeout">
+                <NumberInput
+                    value={Number(config.timeout) || 0}
+                    onPlus={() => calcTimeout(+1)}
+                    onMinus={() => calcTimeout(-1)}
+                    onChange={onTimeoutChange}
+                    inputName="bootloader-timeout-input"
+                    inputAriaLabel="Bootloader Timeout"
+                    minusBtnAriaLabel="minus"
+                    plusBtnAriaLabel="plus"
+                />
+            </FormGroup>
             <FormGroup label={_("Boot entry")} fieldId="graphical-console-resolution">
                 <FormSelect value={config.boot_entries.selected || config.boot_entries.boot_entries[0] || ""} onChange={(_event, value) => setEntry(value)}>
                     {config.boot_entries.boot_entries.map((value, idx) =>

--- a/src/pages/boot_options.tsx
+++ b/src/pages/boot_options.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { Form, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 import { useBootKitContext } from '../state/bootkit_provider';
-// import { fsinfo } from 'cockpit/fsinfo';
 
 const _ = cockpit.gettext;
 
 export const BootOptions = () => {
-    const { config, bootEntries, setBootEntry } = useBootKitContext();
+    const { config, updateConfig } = useBootKitContext();
 
     const setEntry = (entry: string) => {
-        setBootEntry(entry);
+        updateConfig("boot_entries.selected", entry);
     };
 
     return (
         <Form>
             <FormGroup label={_("Boot entry")} fieldId="graphical-console-resolution">
-                <FormSelect value={config.selected_kernel || bootEntries[0] || ""} onChange={(_event, value) => setEntry(value)}>
-                    {bootEntries.map((value, idx) =>
-                        <FormSelectOption key={idx} label={value} value={value} />
+                <FormSelect value={config.boot_entries.selected || config.boot_entries.boot_entries[0] || ""} onChange={(_event, value) => setEntry(value)}>
+                    {config.boot_entries.boot_entries.map((value, idx) =>
+                        <FormSelectOption key={idx} label={value.title || value.name} value={value.name} />
                     )}
                 </FormSelect>
             </FormGroup>

--- a/src/pages/kernel_params.tsx
+++ b/src/pages/kernel_params.tsx
@@ -3,28 +3,17 @@ import React from 'react';
 import { Button, Form, FormFieldGroup, FormFieldGroupHeader, FormGroup, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 import { useBootKitContext } from '../state/bootkit_provider';
-import { KeyValueMap } from '../state/bootkitd';
+import { BootkitGrub2ConsoleConfig } from '../state/bootkitd';
 
 const _ = cockpit.gettext;
 
-const GraphicalConsole = ({ grubValues, updateValue }: { grubValues: KeyValueMap, updateValue: (key: string, value: string) => void }) => {
-    const resolutionValue = () => {
-        const resolution = grubValues.GRUB_GFXMODE?.value;
+const Grub2ConsoleConfig = ({ config }: { config: BootkitGrub2ConsoleConfig }) => {
+    const { updateConsoleConfig } = useBootKitContext();
 
-        if (!resolution || resolution === "auto")
-            return _("Autodetect by grub2");
-
-        return resolution;
-    };
-
-    const isGraphicsEnabled = (): boolean => {
-        return grubValues.GRUB_TERMINAL?.value === "gfxterm";
-    };
-
-    if (!isGraphicsEnabled()) {
+    if (!config.graphical_enabled) {
         return (
             <FormGroup label={_("Graphical console")} fieldId="graphical-console">
-                <Button variant="primary" onClick={() => updateValue("GRUB_TERMINAL", "gfxterm")}>{_("Enable")}</Button>
+                <Button variant="primary" onClick={() => updateConsoleConfig("Grub2", "graphical_enabled", true) }>{_("Enable")}</Button>
             </FormGroup>
         );
     }
@@ -36,13 +25,13 @@ const GraphicalConsole = ({ grubValues, updateValue }: { grubValues: KeyValueMap
                     className='pf-v6-c-form__label-text'
                     titleText={{ text: _("Graphical console"), id: 'graphical-console' }}
                     actions={
-                        <Button variant="secondary" onClick={() => updateValue("GRUB_TERMINAL", "console")}>{_("Disable")}</Button>
+                        <Button variant="secondary" onClick={() => updateConsoleConfig("Grub2", "graphical_enabled", false)}>{_("Disable")}</Button>
                     }
                 />
             }
         >
             <FormGroup label={_("Console resolution")} fieldId="graphical-console-resolution">
-                <FormSelect value={resolutionValue()} onChange={(_event, value) => updateValue("GRUB_GFXMODE", value)}>
+                <FormSelect value={config.console_resolution} onChange={(_event, value) => updateConsoleConfig("Grub2", "console_resolution", value)}>
                     <FormSelectOption label={_("Autodetect by grub2")} value="auto" />
                     <FormSelectOption label='320x200' value='320x200' />
                     <FormSelectOption label='640x400' value='640x400' />
@@ -54,56 +43,38 @@ const GraphicalConsole = ({ grubValues, updateValue }: { grubValues: KeyValueMap
                 <TextInput
                     id="graphical-console-theme-text"
                     name="graphical-console-theme-text"
-                    value={grubValues.GRUB_THEME?.value}
-                    onChange={(_event, value) => updateValue("GRUB_THEME", value)}
+                    value={config.console_theme || ""}
+                    onChange={(_event, value) => updateConsoleConfig("Grub2", "console_theme", value)}
                 />
             </FormGroup>
         </FormFieldGroup>
     );
 };
 
-export const KernelParameters = () => {
-    const context = useBootKitContext();
+const ConsoleConfig = () => {
+    const { config } = useBootKitContext();
 
-    const updateValue = (key: string, value: string) => {
-        context.updateConfig(key, value);
-    };
+    if (config.console?.loader === "Grub2") {
+        return <Grub2ConsoleConfig config={config.console} />;
+    }
+
+    return null;
+};
+
+export const KernelParameters = () => {
+    const { config, updateConfig } = useBootKitContext();
 
     return (
         <Form>
             <FormGroup label={_("Kernel parameters")} fieldId="key">
                 <TextInput
                     aria-label="Kernel parameters"
-                    value={context.config.value_map.GRUB_CMDLINE_LINUX_DEFAULT?.value || ""}
+                    value={config.kernel_arguments || ""}
                     placeholder=""
-                    onChange={(_event, value) => updateValue("GRUB_CMDLINE_LINUX_DEFAULT", value)}
+                    onChange={(_event, value) => updateConfig("kernel_arguments", value)}
                 />
             </FormGroup>
-            {/* <FormGroup label={_("CPU Mitigations")} fieldId="mitigations">
-                <FormSelect>
-                    <FormSelectOption label='Auto + no SMT' />
-                    <FormSelectOption label='Auto' />
-                    <FormSelectOption label='Off' />
-                    <FormSelectOption label='Manually' />
-                </FormSelect>
-            </FormGroup> */}
-            <GraphicalConsole grubValues={context.config.value_map} updateValue={updateValue} />
-            {/*   <FormFieldGroup
-                header={
-                    <FormFieldGroupHeader
-                        titleText={{ text: _("Serial console"), id: 'serial-console' }}
-                        actions={
-                            <>
-                                <Button variant="primary">{_("Enable")}</Button>
-                            </>
-                        }
-                    />
-                }
-            >
-                <FormGroup label={_("Console arguments")} fieldId="serial-console-arguments">
-                    <TextInput id="serial-console-arg-text" name="serial-console-arg-text" value='Arguments here' onChange={() => { }} />
-                </FormGroup>
-            </FormFieldGroup> */}
+            <ConsoleConfig />
         </Form>
     );
 };

--- a/src/pages/snapshots.tsx
+++ b/src/pages/snapshots.tsx
@@ -18,40 +18,48 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 import { ListingTable } from "cockpit-components-table.jsx";
 import { useBootKitContext } from "../state/bootkit_provider";
 import { useDialogs } from "dialogs";
-import { BootkitSnapshots, Grub2SnapshotData } from "../state/bootkitd";
+import { BootkitSnapshot, BootkitSnapshotConfig, BootkitSnapshots } from "../state/bootkitd";
 
 const _ = cockpit.gettext;
 
-const GrubConfig = ({ data }: { data: Grub2SnapshotData }) => {
+const SnapshotConfig = ({ name, config }: { name: string, config: BootkitSnapshotConfig}) => {
     const [diffToggle, setDiffToggle] = React.useState(false);
     const [configToggle, setConfigToggle] = React.useState(false);
 
     return (
-        <Accordion asDefinitionList>
-            <AccordionItem isExpanded={diffToggle}>
-                <AccordionToggle
-                    id="grub-config-diff"
-                    onClick={() => setDiffToggle((old) => !old)}
-                >
-                    {_("Difference between current grub config")}
-                </AccordionToggle>
-                <AccordionContent>
-                    <pre>
-                        {data.diff || _("Identical to the current config")}
-                    </pre>
-                </AccordionContent>
-            </AccordionItem>
+        <>
             <AccordionItem isExpanded={configToggle}>
                 <AccordionToggle
                     id="grub-config-file"
                     onClick={() => setConfigToggle((old) => !old)}
                 >
-                    {_("Full GRUB config file")}
+                    { name }
                 </AccordionToggle>
                 <AccordionContent>
-                    <pre>{data.snapshot.grub_config}</pre>
+                    <pre>{config.contents}</pre>
                 </AccordionContent>
             </AccordionItem>
+            <AccordionItem isExpanded={diffToggle}>
+                <AccordionToggle
+                    id="grub-config-diff"
+                    onClick={() => setDiffToggle((old) => !old)}
+                >
+                    {_("Difference between current config")}
+                </AccordionToggle>
+                <AccordionContent>
+                    <pre>
+                        {config.diff || _("Identical to the current config")}
+                    </pre>
+                </AccordionContent>
+            </AccordionItem>
+        </>
+    );
+};
+
+const SnapshotConfigs = ({ snapshot }: { snapshot: BootkitSnapshot }) => {
+    return (
+        <Accordion asDefinitionList>
+            {Object.entries(snapshot.configs).map(([name, config]) => <SnapshotConfig key={name} name={name} config={config} />)}
         </Accordion>
     );
 };
@@ -144,11 +152,11 @@ export const Snapshots = () => {
     const { snapshots } = useBootKitContext();
 
     const isSelected = (snapData: BootkitSnapshots, idx: number) => {
-        // selected snapshot is either defined by selected_grub_id
-        // or selected snapshot is the last snapshot if selected_grub_id is not defined
-        if (snapData.selected.grub2_snapshot_id) {
-            const selectedId = snapData.selected.grub2_snapshot_id;
-            const snapshotId = snapData.snapshots[idx].snapshot.id;
+        // selected snapshot is either selected by id
+        // or selected snapshot is the last snapshot if selected is not defined
+        if (snapData.selected) {
+            const selectedId = snapData.selected;
+            const snapshotId = snapData.snapshots[idx].id;
             return selectedId === snapshotId;
         } else {
             // The latest created snapshot is always the first in the list
@@ -167,9 +175,9 @@ export const Snapshots = () => {
                 { title: _("Selected kernel") },
                 { title: _("Created") },
             ]}
-            rows={snapshots.snapshots.map((data, idx) => {
-                const snapshot = data.snapshot;
+            rows={snapshots.snapshots.map((snapshot, idx) => {
                 const selected = isSelected(snapshots, idx);
+                const kernel = snapshot.kernel?.title || snapshot.kernel?.name || _("Default");
                 return {
                     columns: [
                         { title: snapshot.id },
@@ -178,8 +186,8 @@ export const Snapshots = () => {
                                 ? _("Yes")
                                 : _("No"),
                         },
-                        { title: snapshot.grub_config.slice(0, 20) },
-                        { title: snapshot.selected_kernel || _("Default") },
+                        // { title: snapshot.grub_config.slice(0, 20) },
+                        { title: kernel },
                         { title: snapshot.created },
                         {
                             title: (
@@ -188,7 +196,7 @@ export const Snapshots = () => {
                             props: { className: "pf-v6-c-table__action" },
                         },
                     ],
-                    expandedContent: <GrubConfig data={data} />,
+                    expandedContent: <SnapshotConfigs snapshot={snapshot} />,
                 };
             })}
         />

--- a/src/state/bootkit_provider.tsx
+++ b/src/state/bootkit_provider.tsx
@@ -2,25 +2,27 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 
 import cockpit from 'cockpit';
 import {
+    BKPath,
+    BKPathValue,
+    BootkitConfig,
+    BootkitConfigsRaw,
+    BootkitConsoleConfigs,
     bootkitdGetVersion,
-    bootKitLoadBootEntries,
-    bootKitLoadConfig,
-    bootKitLoadSnapshots,
-    bootKitPing,
-    bootKitRemoveSnapshot,
-    bootKitSaveGrubConfig,
-    bootKitSelectSnapshot,
+    bootkitLoadConfig,
+    bootkitLoadConfigsRaw,
+    bootkitLoadSnapshots,
+    bootkitPing,
+    bootkitRemoveSnapshot,
+    bootkitSaveConfig,
+    bootkitSelectSnapshot,
     BootkitSnapshots,
-    bootKitUseCurrentSnapshot,
-    Grub2Config,
-    Grub2ConfigInternal,
+    bootkitUseCurrentSnapshot,
+    DBUS_NAME,
+    DBUS_PATH,
     JsonPromise,
-    KeyValue,
     parseBootkitJson,
+    setPathValue,
 } from "./bootkitd";
-
-const DBUS_NAME = "org.opensuse.bootkit";
-const DBUS_PATH = "/org/opensuse/bootkit";
 
 export interface BootkitState {
     loading: boolean;
@@ -29,8 +31,8 @@ export interface BootkitState {
 }
 
 export interface BootKitContextType {
-    config: Grub2Config,
-    bootEntries: string[],
+    config: BootkitConfig,
+    configsRaw: BootkitConfigsRaw,
     snapshots: BootkitSnapshots,
     serviceAvailable: boolean,
     serviceVersion: string | null,
@@ -40,14 +42,14 @@ export interface BootKitContextType {
     removeSnapshot: (id: number) => void,
     selectSnapshot: (id: number) => void,
     selectCurrentSnapshot: () => void,
-    updateConfig: (key: KeyValue | string, value: string) => void,
-    setBootEntry: (entry: string) => void,
+    updateConfig: <K extends BKPath<BootkitConfig>>(key: K, value: BKPathValue<BootkitConfig, K>) => void,
+    updateConsoleConfig: <L extends BootkitConsoleConfigs["loader"], K extends BKPath<BootkitConsoleConfigs & { loader: L }>>(loader: L, key: K, value: BKPathValue<BootkitConsoleConfigs & { loader: L }, K>) => void,
 }
 
 const BootKitContext = createContext<BootKitContextType>({
-    config: { value_list: [], value_map: {}, internal_list: [] },
-    bootEntries: [],
-    snapshots: { snapshots: [], selected: {} },
+    config: { boot_entries: { boot_entries: [] } },
+    configsRaw: { configs: [] },
+    snapshots: { snapshots: [] },
     serviceAvailable: false,
     serviceVersion: null,
     state: { loading: true, saving: false },
@@ -57,7 +59,7 @@ const BootKitContext = createContext<BootKitContextType>({
     selectSnapshot: () => { },
     selectCurrentSnapshot: () => { },
     updateConfig: () => { },
-    setBootEntry: () => { },
+    updateConsoleConfig: () => { },
 });
 export const useBootKitContext = () => useContext(BootKitContext);
 
@@ -89,104 +91,84 @@ function bootKitCall<T>(callback: (...arg: BKArg[]) => Promise<JsonPromise<T>>, 
 export function BootKitProvider({ children }: { children: React.ReactNode }) {
     const [serviceAvailable, setServiceAvailable] = useState(false);
     const [serviceVersion, setServiceVersion] = useState<string | null>(null);
-    const [config, setConfig] = useState<Grub2Config>({ value_list: [], value_map: {}, internal_list: [] });
-    const [snapshots, setSnapshots] = useState<BootkitSnapshots>({ snapshots: [], selected: {} });
-    const [bootEntries, setBootEntries] = useState<string[]>([]);
+    const [config, setConfig] = useState<BootkitConfig>({ boot_entries: { boot_entries: [] } });
+    const [configsRaw, setConfigsRaw] = useState<BootkitConfigsRaw>({ configs: [] });
+    const [snapshots, setSnapshots] = useState<BootkitSnapshots>({ snapshots: [] });
     const [state, setState] = useState<BootkitState>({ loading: true, saving: false });
 
-    const updateConfig = React.useCallback((key: KeyValue | string, value: string) => {
-        let keyvalue = key as KeyValue;
-        if (typeof key === "string") {
-            keyvalue = config.value_map[key];
-            // For keyalues that do exists,
-            // make sure that the T is always "KeyValue" to keep backend happy.
-            // Else we'll crete a completely new one
-            if (keyvalue) {
-                keyvalue.t = "KeyValue";
-            } else {
-                const lineNum = config.internal_list.length;
-                keyvalue = {
-                    t: "KeyValue",
-                    key,
-                    value,
-                    changed: true,
-                    line: lineNum,
-                    original: `${key}="${value}"`,
-                };
-                config.internal_list.push(keyvalue);
-                config.value_list.push(keyvalue);
-                config.value_map[key] = keyvalue;
-                setConfig({ ...config });
-                return;
-            }
-        }
-
-        keyvalue.changed = true;
-        keyvalue.value = value;
-        const line = config.value_list.findIndex(kv => kv.line === keyvalue.line);
-        config.value_list[line] = keyvalue;
-        config.internal_list[keyvalue.line] = keyvalue;
-        // only save the last entry of key to keyvalue store
-        // to replicate the behavior of grub
-        if (config.value_map[keyvalue.key]?.line === keyvalue.line) {
-            config.value_map[keyvalue.key] = keyvalue;
-        }
-        setConfig({ ...config });
+    const saveConfig = React.useCallback(async () => {
+        updateState({ saving: true });
+        console.log("Saving config:", config);
+        await saveConfigBC(config);
+        await loadAll();
+        updateState({ saving: false });
     }, [config]);
 
     const updateState = (state: Partial<BootkitState>) => {
         setState(old => ({ ...old, ...state }));
     };
 
-    const setBootEntry = React.useCallback((entry: string) => {
-        config.selected_kernel = entry;
-        setConfig({ ...config });
-    }, [config]);
-
-    const saveGrubConfig = React.useCallback(async () => {
-        updateState({ saving: true });
-        await saveConfig(config);
-        await loadAll();
-        updateState({ saving: false });
-    }, [config]);
-
     const setStateError = (error: string) => {
         setState(old => ({ ...old, error }));
     };
 
-    const updateGrub2Config = (data: Grub2ConfigInternal) => {
-        const value_list = data.value_list.filter(val => val.t === "KeyValue");
-        setConfig({
-            value_list,
-            value_map: data.value_map,
-            internal_list: data.value_list,
-            selected_kernel: data.selected_kernel,
-            config_diff: data.config_diff,
+    function updateConfigValue<K extends BKPath<BootkitConfig>>(key: K, value: BKPathValue<BootkitConfig, K>) {
+        setConfig(old => {
+            const copy = { ...old };
+            setPathValue(copy, key, value);
+            return copy;
         });
+    }
+
+    function updateConsoleConfig<L extends BootkitConsoleConfigs["loader"], K extends BKPath<BootkitConsoleConfigs & { loader: L }>>(loader: L, key: K, value: BKPathValue<BootkitConsoleConfigs & { loader: L }, K>) {
+        setConfig(old => {
+            if (!old.console) {
+                console.error("Console settings are not supported for this backend");
+                return old;
+            }
+
+            if (old.console.loader !== loader) {
+                console.error("Console setting mismach. Cannot set settings for", loader, "when", old.console.loader, "is selected");
+                return old;
+            }
+
+            setPathValue(old.console, key, value);
+            const copy = { ...old };
+            return copy;
+        });
+    }
+
+    const updateConfig = (data: BootkitConfig) => {
+        setConfig(data);
+    };
+
+    const updateConfigsRaw = (data: BootkitConfigsRaw) => {
+        console.log("bootkitconfig: raw", data);
+        setConfigsRaw(data);
     };
 
     const removeAndLoadSnapshot = async (id: number) => {
         updateState({ saving: true });
-        await removeSnapshot(id);
+        await removeSnapshotBC(id);
         updateState({ saving: false });
-        await loadSnapshots();
+        await loadSnapshotsBC();
     };
 
     const selectAndLoadSnapshot = async (id: number) => {
-        await selectSnapshot(id);
+        await selectSnapshotBC(id);
         await loadAll();
     };
 
     const useAndLoadCurrentSnapshot = async () => {
-        await useCurrentSnapshot();
+        await useCurrentSnapshotBC();
         await loadAll();
     };
 
     const loadAll = async () => {
         updateState({ loading: true });
-        await loadConfig();
-        await loadBootEntries();
-        await loadSnapshots();
+        await loadConfigBC();
+        await loadConfigsRawBC();
+        await loadSnapshotsBC();
         updateState({ loading: false });
     };
 
@@ -200,7 +182,7 @@ export function BootKitProvider({ children }: { children: React.ReactNode }) {
 
         const timeout = setInterval(() => {
             // TODO: error handling
-            bootKitPing();
+            bootkitPing();
         }, 10000);
 
         return () => {
@@ -233,33 +215,35 @@ export function BootKitProvider({ children }: { children: React.ReactNode }) {
             }, async (_path, _iface, signal) => {
                 if (signal === "FileChanged") {
                     /// TODO: warn about state beign changed if this didn't happen because we saved config ourselves
-                    await loadConfig();
+                    await loadConfigBC();
                 }
             });
         })();
     }, []);
 
-    const saveConfig = bootKitCall(bootKitSaveGrubConfig, setStateError);
-    const loadConfig = bootKitCall(bootKitLoadConfig, setStateError, updateGrub2Config);
-    const loadSnapshots = bootKitCall(bootKitLoadSnapshots, setStateError, setSnapshots);
-    const loadBootEntries = bootKitCall(bootKitLoadBootEntries, setStateError, (entries) => setBootEntries(entries.entries));
-    const removeSnapshot = bootKitCall(bootKitRemoveSnapshot, setStateError);
-    const selectSnapshot = bootKitCall(bootKitSelectSnapshot, setStateError);
-    const useCurrentSnapshot = bootKitCall(bootKitUseCurrentSnapshot, setStateError);
+    const saveConfigBC = bootKitCall(bootkitSaveConfig, setStateError);
+    const loadConfigBC = bootKitCall(bootkitLoadConfig, setStateError, updateConfig);
+    const loadConfigsRawBC = bootKitCall(bootkitLoadConfigsRaw, setStateError, updateConfigsRaw);
+    const loadSnapshotsBC = bootKitCall(bootkitLoadSnapshots, setStateError, setSnapshots);
+    const removeSnapshotBC = bootKitCall(bootkitRemoveSnapshot, setStateError);
+    const selectSnapshotBC = bootKitCall(bootkitSelectSnapshot, setStateError);
+    const useCurrentSnapshotBC = bootKitCall(bootkitUseCurrentSnapshot, setStateError);
 
     return (
         <BootKitContext.Provider
             value={{
+                // state
+                state,
+                config,
+                configsRaw,
+                snapshots,
                 serviceAvailable,
                 serviceVersion,
-                config,
-                bootEntries,
-                updateConfig,
+                // functions
+                saveConfig,
+                updateConfig: updateConfigValue,
+                updateConsoleConfig,
                 resetConfig,
-                saveConfig: saveGrubConfig,
-                setBootEntry,
-                state,
-                snapshots,
                 removeSnapshot: removeAndLoadSnapshot,
                 selectSnapshot: selectAndLoadSnapshot,
                 selectCurrentSnapshot: useAndLoadCurrentSnapshot,

--- a/src/state/bootkitd.ts
+++ b/src/state/bootkitd.ts
@@ -1,65 +1,123 @@
 import cockpit from 'cockpit';
 
-const DBUS_NAME = "org.opensuse.bootkit";
-const DBUS_PATH = "/org/opensuse/bootkit";
+export const DBUS_NAME = "org.opensuse.bootkit";
+export const DBUS_PATH = "/org/opensuse/bootkit";
 
-export interface KeyValue {
-    t: "KeyValue";
-    original: string;
-    line: number;
-    changed: boolean;
-    key: string;
-    value: string;
-}
+type BKKeys<K extends string | number, IsTop> = IsTop extends true ? K : `.${K}`
 
-export interface RawLine {
-    t: "String";
-    raw_line: string;
-}
+// Map type into "foo.bar" path
+export type BKPath<T, IsTop = true, K extends keyof T = keyof T> =
+  K extends string | number
+    ? `${BKKeys<K, IsTop>}${'' | (T[K] extends object ? T[K] extends unknown[] ? '' : BKPath<T[K], false> : '')}`
+    : never
 
-export type KeyValueMap = Record<string, KeyValue>;
+// infer type of a member based on "foo.bar" path
+export type BKPathValue<T, P extends string> = P extends `${infer K}.${infer R}`
+  ? K extends keyof T
+    ? BKPathValue<T[K], `${R}`>
+    : never
+  : P extends `${infer K}`
+    ? K extends keyof T
+      ? T[K]
+      : never
+    : never;
 
-export type Grub2Snapshot = {
-    // Auto incrementing snapshot id
-    id: number,
-    // /etc/default/grub config
-    grub_config: string,
-    // selected kernel that's booted to, if it's actually specified
-    selected_kernel?: string | null | undefined
-    // when snapshot was created
-    created: string,
+export const getPathKeys = (path: string): string[] => {
+    const paths = path.split(".");
+    return paths;
 };
 
-export interface Grub2SnapshotData {
-    snapshot: Grub2Snapshot,
-    // diff between current Grub2 config, if any
-    diff?: string | null | undefined,
+export const setPathValue = (obj: object, path: string, value: unknown) => {
+    // TODO: typesafety
+    const paths = path.split(".");
+    let curr = obj;
+    for (let idx = 0; idx <= paths.length; idx++) {
+        const path = paths[idx];
+        if (idx === paths.length - 1) {
+            // @ts-expect-error Assume curr being a valid object
+            curr[path] = value;
+        } else {
+            // @ts-expect-error Assume curr being a valid object
+            curr = curr[path];
+        }
+    }
+};
+
+export interface BootkitGrub2ConsoleConfig {
+    graphical_enabled: boolean;
+    /** Seleceted console resolution or "auto" */
+    console_resolution: string;
+    console_theme?: string | null;
 }
 
-export interface Grub2SelectedSnapshot {
-    // id of selected Grub2Snapshot. If none is set, select snapshot with
-    // biggest ID
-    grub2_snapshot_id?: number | null | undefined;
+/**
+ * Discriminated union matching `#[serde(tag = "loader")]`
+ */
+export type BootkitConsoleConfigs =
+    | { loader: "SystemdBoot" }
+    | (BootkitGrub2ConsoleConfig & { loader: "Grub2" });
+
+export interface BootkitBootEntry {
+    /** "Raw" name, usually containing more technical info */
+    name: string;
+    /** Pretty name, if available */
+    title?: string | null;
+}
+
+export interface BootkitBootEntries {
+    selected?: string | null;
+    boot_entries: BootkitBootEntry[];
+}
+
+export interface BootkitConfig {
+    timeout?: string | null;
+    boot_entries: BootkitBootEntries;
+    kernel_arguments?: string | null;
+    /** Possible mismatches of currently selected config and system's state. */
+    config_diffs?: { [key: string]: string };
+    /** Console configs for loaders that support them */
+    console?: BootkitConsoleConfigs | null;
+}
+
+/**
+ * Discriminated union matching `#[serde(tag = "file_type")]`
+ */
+export type BootkitRawFile =
+    | { file_type: "Grub2Config"; values: [string, string][] }
+    | { file_type: "SystemdBootEntry"; values: [string, string][] }
+    | { file_type: "SystemdBootLoader"; values: [string, string][] };
+
+export interface BootkitConfigRaw {
+    file: BootkitRawFile;
+    file_path: string;
+}
+
+export interface BootkitConfigsRaw {
+    configs: BootkitConfigRaw[];
+}
+
+export interface BootkitSnapshotConfig {
+    contents: string;
+    diff?: string | null;
+}
+
+export interface BootkitSnapshot {
+    id: number;
+    /** Timestamp from database (ISO 8601 string) */
+    created: string;
+    /** Raw bootloader specific config(s) */
+    configs: { [key: string]: BootkitSnapshotConfig };
+    /** Selected kernel, None means default */
+    kernel?: BootkitBootEntry | null;
 }
 
 export interface BootkitSnapshots {
-    snapshots: Grub2SnapshotData[],
-    selected: Grub2SelectedSnapshot,
+    selected?: number | null;
+    snapshots: BootkitSnapshot[];
 }
 
-export interface Grub2ConfigInternal {
-    value_map: KeyValueMap;
-    value_list: (KeyValue | RawLine)[];
-    selected_kernel?: string | null | undefined;
-    config_diff?: string | null | undefined;
-}
-
-export interface Grub2Config {
-    value_map: KeyValueMap;
-    value_list: KeyValue[];
-    internal_list: (KeyValue | RawLine)[];
-    selected_kernel?: string | null | undefined;
-    config_diff?: string | null | undefined;
+export interface BootkitSnapshotSelect {
+    snapshot_id: number;
 }
 
 export type JsonPromise<T> = string[] | T
@@ -81,51 +139,49 @@ export const bootkitdGetVersion = () => {
                     .call(DBUS_PATH, "org.opensuse.bootkit.Info", "GetVersion") as Promise<string[]>;
 };
 
-export const bootKitPing = () => {
+export const bootkitPing = () => {
     return bootkitdClient()
                     .call(DBUS_PATH, "org.opensuse.bootkit.Info", "Ping");
 };
 
-export const bootKitRemoveSnapshot = (id: number) => {
+export const bootkitLoadConfig = () => {
+    return bootkitdClient()
+                    .call(DBUS_PATH, "org.opensuse.bootkit.Config", "GetConfig") as Promise<JsonPromise<BootkitConfig>>;
+};
+
+export const bootkitLoadConfigsRaw = () => {
+    return bootkitdClient()
+                    .call(DBUS_PATH, "org.opensuse.bootkit.ConfigRaw", "GetConfigsRaw") as Promise<JsonPromise<BootkitConfigsRaw>>;
+};
+
+export const bootkitLoadSnapshots = () => {
+    return bootkitdClient()
+                    .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "GetSnapshots") as Promise<JsonPromise<BootkitSnapshots>>;
+};
+
+export const bootkitSaveConfig = (config: BootkitConfig) => {
+    return bootkitdClient()
+                    .call(DBUS_PATH, "org.opensuse.bootkit.Config", "SaveConfig", [JSON.stringify(config)]) as Promise<JsonPromise<string>>;
+};
+
+export const bootkitSnapshotFromSystem = () => {
+    return bootkitdClient()
+                    .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "SnapshotFromSystem", []) as Promise<JsonPromise<string>>;
+};
+
+export const bootkitRemoveSnapshot = (id: number) => {
     const arg = { snapshot_id: id };
     return bootkitdClient()
                     .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "RemoveSnapshot", [JSON.stringify(arg)]) as Promise<JsonPromise<string>>;
 };
 
-export const bootKitSelectSnapshot = (id: number) => {
+export const bootkitSelectSnapshot = (id: number) => {
     const arg = { snapshot_id: id };
     return bootkitdClient()
                     .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "SelectSnapshot", [JSON.stringify(arg)]) as Promise<JsonPromise<string>>;
 };
 
-export const bootKitUseCurrentSnapshot = () => {
+export const bootkitUseCurrentSnapshot = () => {
     return bootkitdClient()
                     .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "UseCurrentSnapshot", []) as Promise<JsonPromise<string>>;
-};
-
-export const bootKitLoadSnapshots = (): Promise<JsonPromise<BootkitSnapshots>> => {
-    return bootkitdClient()
-                    .call(DBUS_PATH, "org.opensuse.bootkit.Snapshot", "GetSnapshots") as Promise<JsonPromise<BootkitSnapshots>>;
-};
-
-export const bootKitLoadConfig = () => {
-    return bootkitdClient()
-                    .call(DBUS_PATH, "org.opensuse.bootkit.Config", "GetConfig") as Promise<JsonPromise<Grub2ConfigInternal>>;
-};
-
-export const bootKitLoadBootEntries = () => {
-    return bootkitdClient()
-                    .call(DBUS_PATH, "org.opensuse.bootkit.BootEntry", "GetEntries") as Promise<JsonPromise<{entries: string[]}>>;
-};
-
-export const bootKitSaveGrubConfig = (config: Grub2Config) => {
-    // TODO: polling and status update callbacks
-    const data: Grub2ConfigInternal = {
-        value_map: config.value_map,
-        value_list: config.internal_list,
-        selected_kernel: config.selected_kernel,
-    };
-
-    return bootkitdClient()
-                    .call(DBUS_PATH, "org.opensuse.bootkit.Config", "SaveConfig", [JSON.stringify(data)]) as Promise<JsonPromise<string>>;
 };


### PR DESCRIPTION
Support new bootkitd API that's going to be introduced in `0.5.0`. This should merge after that's released.

Also added `Timeout` to `Boot Options` sections since it's going to be supported by bootkitd